### PR TITLE
enlarge sampling buffer size

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -9,7 +9,7 @@ use std::marker::PhantomData;
 
 pub const BUCKETS: usize = (1 << 12);
 pub const BUCKETS_ASSOCIATIVITY: usize = 4;
-pub const BUFFER_LENGTH: usize = (1 << 18) / std::mem::size_of::<Entry<UnresolvedFrames>>();
+pub const BUFFER_LENGTH: usize = (1 << 19) / std::mem::size_of::<Entry<UnresolvedFrames>>();
 
 pub struct Entry<T> {
     pub item: T,


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

This PR enlarges the `BUFFER_LENGTH` of the collector to avoid memory dynamic allocation in the signal handler.

According to SIGNAL safety definition, we cannot use `malloc` in the signal handler but the `BUFFER_LENGTH` is too small will cause the process crash.