### PR TITLE
disable `#![feature(test)]` outside of tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!};
 //! ```
 
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 #[cfg(test)]
 extern crate test;
 


### PR DESCRIPTION
This allows `pprof` to be used by the stable compiler.

Note: we could extract the benchmark and run them using `criterion` or `bencher` so the entire package can be free of `#![feature]`s. But the current benchmarks are against the private `collector` module, so nothing is refactored for now.