### PR TITLE
Miscellaneous tidying up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,29 +11,28 @@ readme = "README.md"
 
 [features]
 flamegraph = ["inferno"]
-protobuf = ["prost", "bytes", "prost-derive", "prost-build"]
+protobuf = ["prost", "prost-derive", "prost-build"]
 
 [dependencies]
 backtrace = "0.3"
 lazy_static = "1.4.0"
-nix = "0.15.0"
-quick-error = "1.2.2"
-inferno = { version = "0.9.0", optional = true }
-log = "0.4"
-spin = "0.5.2"
-rustc-demangle = "0.1.16"
-tempfile = "3.1.0"
-memmap = "0.7.0"
 libc = "0.2"
-prost = { version="0.5", optional = true }
-bytes = { version="0.4.12", optional = true }
-prost-derive = { version="0.5", optional = true }
+log = "0.4"
+nix = "0.16.0"
+rustc-demangle = "0.1.16"
+spin = "0.5.2"
+tempfile = "3.1.0"
+thiserror = "1.0"
+
+inferno = { version = "0.9.0", default-features = false, features = ["nameattr"], optional = true }
+prost = { version = "0.6", optional = true }
+prost-derive = { version = "0.6", optional = true }
 
 [dev-dependencies]
 rand = "0.7.2"
 
 [build-dependencies]
-prost-build = { version = "0.5", optional = true }
+prost-build = { version = "0.6", optional = true }
 
 [[example]]
 name = "flamegraph"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 `pprof` is a cpu profiler that can be easily integrated into a rust program.
 
 [![Crates.io](https://img.shields.io/crates/v/pprof.svg)](https://crates.io/crates/pprof)
+ [![Dependency Status](https://deps.rs/repo/github/tikv/pprof-rs/status.svg)](https://deps.rs/repo/github/tikv/pprof-rs)
 
 ## Usage
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,17 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-quick_error! {
-    #[derive(Debug)]
-    pub enum Error {
-        NixError(err: nix::Error) {
-            from()
-            cause(err)
-            description(err.description())
-        }
-        IoError(err: std::io::Error) {
-            from()
-            cause(err)
-            description(err.description())
-        }
-        CreatingError
-        Running
-        NotRunning
-    }
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    NixError(#[from] nix::Error),
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+    #[error("create profiler error")]
+    CreatingError,
+    #[error("start running cpu profiler error")]
+    Running,
+    #[error("stop running cpu profiler error")]
+    NotRunning,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -157,14 +157,10 @@ unsafe impl Send for Symbol {}
 impl From<&backtrace::Symbol> for Symbol {
     fn from(symbol: &backtrace::Symbol) -> Self {
         Symbol {
-            name: symbol
-                .name()
-                .and_then(|name| Some(name.as_bytes().to_vec())),
+            name: symbol.name().map(|name| name.as_bytes().to_vec()),
             addr: symbol.addr(),
             lineno: symbol.lineno(),
-            filename: symbol
-                .filename()
-                .and_then(|filename| Some(filename.to_owned())),
+            filename: symbol.filename().map(|filename| filename.to_owned()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,10 @@
 //!};
 //! ```
 
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
+
 #[cfg(test)]
 extern crate test;
-
-#[macro_use]
-extern crate quick_error;
 
 /// Define the MAX supported stack depth. TODO: make this variable mutable.
 pub const MAX_DEPTH: usize = 32;
@@ -41,10 +39,10 @@ mod profiler;
 mod report;
 mod timer;
 
-pub use error::{Error, Result};
-pub use frames::{Frames, Symbol};
-pub use profiler::ProfilerGuard;
-pub use report::{Report, ReportBuilder};
+pub use self::error::{Error, Result};
+pub use self::frames::{Frames, Symbol};
+pub use self::profiler::ProfilerGuard;
+pub use self::report::{Report, ReportBuilder};
 
 #[cfg(feature = "protobuf")]
 pub mod protos {

--- a/src/report.rs
+++ b/src/report.rs
@@ -118,7 +118,7 @@ mod flamegraph {
                 .iter()
                 .map(|(key, value)| {
                     let mut line = String::new();
-                    if key.thread_name.len() > 0 {
+                    if !key.thread_name.is_empty() {
                         line.push_str(&key.thread_name);
                     } else {
                         line.push_str(&format!("{:?}", key.thread_id));
@@ -139,7 +139,7 @@ mod flamegraph {
                     line
                 })
                 .collect();
-            if lines.len() > 0 {
+            if !lines.is_empty() {
                 flamegraph::from_lines(
                     &mut flamegraph::Options::default(),
                     lines.iter().map(|s| &**s),
@@ -209,7 +209,7 @@ mod protobuf {
                         line.line = lineno as i64;
                         let mut loc = protos::Location::default();
                         loc.id = id;
-                        loc.line = vec![line].into();
+                        loc.line = vec![line];
                         // the fn_tbl has the same length with loc_tbl
                         fn_tbl.push(function);
                         loc_tbl.push(loc);
@@ -218,8 +218,8 @@ mod protobuf {
                     }
                 }
                 let mut sample = protos::Sample::default();
-                sample.location_id = locs.into();
-                sample.value = vec![*count as i64].into();
+                sample.location_id = locs;
+                sample.value = vec![*count as i64];
                 samples.push(sample);
             }
             let (type_idx, unit_idx) = (str_tbl.len(), str_tbl.len() + 1);
@@ -229,11 +229,11 @@ mod protobuf {
             sample_type.r#type = type_idx as i64;
             sample_type.unit = unit_idx as i64;
             let mut profile = protos::Profile::default();
-            profile.sample_type = vec![sample_type].into();
-            profile.sample = samples.into();
-            profile.string_table = str_tbl.into();
-            profile.function = fn_tbl.into();
-            profile.location = loc_tbl.into();
+            profile.sample_type = vec![sample_type];
+            profile.sample = samples;
+            profile.string_table = str_tbl;
+            profile.function = fn_tbl;
+            profile.location = loc_tbl;
             Ok(profile)
         }
     }


### PR DESCRIPTION
* Update `prost`, `prost-derive`, `prost-build` and `nix` dependencies
* Remove useless dependency (`memmap` and `bytes`)
* Remove useless features of `inferno`
* Replace `quick-error` with `thiserror`
* Fix some clippy warnings

Signed-off-by: koushiro <koushiro.cqx@gmail.com>