### PR TITLE
reset dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ protobuf = ["prost", "prost-derive", "prost-build"]
 
 [dependencies]
 backtrace = "0.3"
-lazy_static = "1.4.0"
-libc = "0.2"
+lazy_static = "1.4"
+libc = "^0.2.66"
 log = "0.4"
-nix = "0.16.0"
-rustc-demangle = "0.1.16"
-spin = "0.5.2"
-tempfile = "3.1.0"
+nix = "0.16"
+rustc-demangle = "0.1"
+spin = "0.5"
+tempfile = "3.1"
 thiserror = "1.0"
 
-inferno = { version = "0.9.0", default-features = false, features = ["nameattr"], optional = true }
+inferno = { version = "0.9", default-features = false, features = ["nameattr"], optional = true }
 prost = { version = "0.6", optional = true }
 prost-derive = { version = "0.6", optional = true }
 


### PR DESCRIPTION
- Ease restrictions on some dependencies.

- Require `^0.2.66` libc to build on mac os

Signed-off-by: Yang Keao <keao.yang@yahoo.com>