### PR TITLE
remove lock in backtrace::backtrace

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -119,15 +119,17 @@ extern "C" fn perf_signal_handler(_signal: c_int) {
     let mut bt: [Frame; MAX_DEPTH] = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
     let mut index = 0;
 
-    backtrace::trace(|frame| {
-        if index < MAX_DEPTH {
-            bt[index] = frame.clone();
-            index += 1;
-            true
-        } else {
-            false
-        }
-    });
+    unsafe {
+        backtrace::trace_unsynchronized(|frame| {
+            if index < MAX_DEPTH {
+                bt[index] = frame.clone();
+                index += 1;
+                true
+            } else {
+                false
+            }
+        });
+    }
 
     if let Some(mut guard) = PROFILER.try_write() {
         if let Ok(profiler) = guard.as_mut() {


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

As reported by @innerr , many threads block in pprof's signal handler. The backtrace is:

```
#0  0x00007f239f7304ed in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f239f72bdcb in _L_lock_883 () from /lib64/libpthread.so.0
#2  0x00007f239f72bc98 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00005613dfe71d74 in backtrace::lock::lock::hea7f3a0f770ef08e ()
#4  0x00005613e07164c6 in pprof::profiler::perf_signal_handler::ha7a30212c5f19df6 ()
#5  <signal handler called>
```

No matter what the purpose is, we shouldn't use lock in signal handler.

Maybe we should also add a deadline for profiler's spin lock.