### PR TITLE
Replace spin with parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ backtrace = "0.3"
 lazy_static = "1.4"
 libc = "^0.2.66"
 log = "0.4"
-nix = "0.16"
-symbolic-demangle = "6.1"
-spin = "0.5"
+nix = "0.17"
+parking_lot = "0.11"
+symbolic-demangle = "7.4"
 tempfile = "3.1"
 thiserror = "1.0"
 
-inferno = { version = "0.9", default-features = false, features = ["nameattr"], optional = true }
+inferno = { version = "0.10", default-features = false, features = ["nameattr"], optional = true }
 prost = { version = "0.6", optional = true }
 prost-derive = { version = "0.6", optional = true }
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,13 +1,14 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::frames::UnresolvedFrames;
 use std::collections::hash_map::DefaultHasher;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::marker::PhantomData;
 
-pub const BUCKETS: usize = (1 << 12);
+use crate::frames::UnresolvedFrames;
+
+pub const BUCKETS: usize = 1 << 12;
 pub const BUCKETS_ASSOCIATIVITY: usize = 4;
 pub const BUFFER_LENGTH: usize = (1 << 18) / std::mem::size_of::<Entry<UnresolvedFrames>>();
 

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,10 +1,11 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use backtrace::Frame;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::os::raw::c_void;
 use std::path::PathBuf;
+
+use backtrace::Frame;
 use symbolic_demangle::demangle;
 
 use crate::{MAX_DEPTH, MAX_THREAD_NAME};

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,9 +1,12 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::frames::Frames;
-use crate::profiler::Profiler;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+
+use parking_lot::RwLock;
+
+use crate::frames::Frames;
+use crate::profiler::Profiler;
 
 use crate::{Error, Result};
 
@@ -16,11 +19,11 @@ pub struct Report {
 /// A builder of `Report`. It builds report from a running `Profiler`.
 pub struct ReportBuilder<'a> {
     frames_post_processor: Option<Box<dyn Fn(&mut Frames)>>,
-    profiler: &'a spin::RwLock<Result<Profiler>>,
+    profiler: &'a RwLock<Result<Profiler>>,
 }
 
 impl<'a> ReportBuilder<'a> {
-    pub(crate) fn new(profiler: &'a spin::RwLock<Result<Profiler>>) -> Self {
+    pub(crate) fn new(profiler: &'a RwLock<Result<Profiler>>) -> Self {
         Self {
             frames_post_processor: None,
             profiler,


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* Replace `spin` with `parking_lot` (`spin` is no longer actively maintained)
* Update all dependencies to latest.