### PR TITLE
[WIP] Support musl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ parking_lot = "0.11"
 symbolic-demangle = "7.4"
 tempfile = "3.1"
 thiserror = "1.0"
+cfg-if = "0.1"
 
 inferno = { version = "0.10", default-features = false, features = ["nameattr"], optional = true }
 prost = { version = "0.6", optional = true }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -101,20 +101,23 @@ fn write_thread_name_fallback(current_thread: libc::pthread_t, name: &mut [libc:
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
-    write_thread_name_fallback(current_thread, name);
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
-    let name_ptr = name as *mut [libc::c_char] as *mut libc::c_char;
-    let ret = unsafe { libc::pthread_getname_np(current_thread, name_ptr, MAX_THREAD_NAME) };
-
-    if ret != 0 {
-        write_thread_name_fallback(current_thread, name);
+cfg_if::cfg_if! {
+    if #[cfg(any(not(any(target_os = "linux", target_os = "macos")), target_env = "musl"))] {
+        fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
+            write_thread_name_fallback(current_thread, name);
+        }
+    } else {
+        fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
+            let name_ptr = name as *mut [libc::c_char] as *mut libc::c_char;
+            let ret = unsafe { libc::pthread_getname_np(current_thread, name_ptr, MAX_THREAD_NAME) };
+        
+            if ret != 0 {
+                write_thread_name_fallback(current_thread, name);
+            }
+        }
     }
 }
+
 
 #[no_mangle]
 extern "C" fn perf_signal_handler(_signal: c_int) {


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

Related with #27 . But there are still problems to build on musl:

1. `symbolic-demangle` has to be modified to avoid dynamic linking with stdc++. `cpp_link_stdlib(None)` can simply solve this.

2. The backtrace works not well:

![image](https://user-images.githubusercontent.com/5244316/87047987-c86b1800-c22d-11ea-8488-03f7978b5c7b.png)

Here is an example running the multithread_flamegraph :cry: .