### PR TITLE
give a reasonable hint for musl-libc based host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ criterion = "0.3"
 rand = "0.8.0"
 
 [build-dependencies]
-prost-build = { version = "0.6", optional = true }
+prost-build = { version = "0.7", optional = true }
 
 [[example]]
 name = "flamegraph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ tempfile = "3.1"
 thiserror = "1.0"
 
 inferno = { version = "0.10", default-features = false, features = ["nameattr"], optional = true }
-prost = { version = "0.6", optional = true }
-prost-derive = { version = "0.6", optional = true }
+prost = { version = "0.7", optional = true }
+prost-derive = { version = "0.7", optional = true }
 
 [dependencies.symbolic-demangle]
 version = "8.0"


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

close #27 . Related issue [prost#202](https://github.com/danburkert/prost/issues/202) and PR [prost#404](https://github.com/danburkert/prost/issues/410) What the error message looks like now:

```
error: failed to run custom build command for `prost-build v0.7.0`

Caused by:
  process didn't exit successfully: `/home/xhe/project/pprof-rs/target/debug/build/prost-build-2018636b0ced6d86/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'Failed to find the protoc binary. The PROTOC environment variable is not set, there is no bundled protoc for this platform, and protoc is not in the PATH', /home/xhe/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.7.0/build.rs:100:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```
