### PR TITLE
implement criterion Profiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,10 @@ required-features = ["protobuf"]
 name = "multithread_flamegraph"
 required-features = ["flamegraph"]
 
+[[example]]
+name = "criterion"
+required-features = ["flamegraph", "criterion"]
+
 [[bench]]
 name = "collector"
 path = "benches/collector.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0"
 inferno = { version = "0.10", default-features = false, features = ["nameattr"], optional = true }
 prost = { version = "0.7", optional = true }
 prost-derive = { version = "0.7", optional = true }
+criterion = {version = "0.3", optional = true}
 
 [dependencies.symbolic-demangle]
 version = "8.0"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ Then `pprof` will generate a svg file according to the profile.
 
 ![tree](https://user-images.githubusercontent.com/5244316/68571082-1f50ff80-049d-11ea-8437-211ab0d80480.png)
 
+## Integrate with `criterion`
+
+With `criterion` feature enabled, a criterion custom profiler is provided in `pprof-rs`.
+
+```
+use pprof::criterion::{PProfProfiler, Output};
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench
+}
+criterion_main!(benches);
+```
+
+After running the benchmark, you can find the flamegraph under `target/criterion/<name-of-benchmark>/profile/`. `protobuf` output is also available, with `Output::Protobuf` option.
+
+For more details, you can check the `examples/criterion.rs`, and the profiling document of [`criterion`](https://bheisler.github.io/criterion.rs/book/user_guide/profiling.html).
+
 ## Why not ...
 
 There have been tons of profilers, why we create a new one? Here we make a comparison between `pprof-rs` and other popular profilers to help you choose the best fit one.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ criterion_main!(benches);
 
 After running the benchmark, you can find the flamegraph under `target/criterion/<name-of-benchmark>/profile/`. `protobuf` output is also available, with `Output::Protobuf` option.
 
-For more details, you can check the `examples/criterion.rs`, and the profiling document of [`criterion`](https://bheisler.github.io/criterion.rs/book/user_guide/profiling.html).
+For more details, you can check the `examples/criterion.rs`, and the profiling document of [`criterion`](https://bheisler.github.io/criterion.rs/book/user_guide/profiling.html). For a quick start, you can run this example with `cargo run --example criterion --release --features="flamegraph criterion" -- --bench --profile-time 5`
 
 ## Why not ...
 

--- a/examples/criterion.rs
+++ b/examples/criterion.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate criterion;
+use criterion::{Criterion, black_box};
+
+use pprof::criterion::{PProfProfiler, Output};
+
+// Thanks to the example provided by @jebbow in his article
+// https://www.jibbow.com/posts/criterion-flamegraphs/
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 | 1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    c.bench_function("Fibonacci", |b| b.iter(|| fibonacci(black_box(20))));
+}
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench
+}
+criterion_main!(benches);

--- a/examples/criterion.rs
+++ b/examples/criterion.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate criterion;
-use criterion::{Criterion, black_box};
+use criterion::{black_box, Criterion};
 
-use pprof::criterion::{PProfProfiler, Output};
+use pprof::criterion::{Output, PProfProfiler};
 
 // Thanks to the example provided by @jebbow in his article
 // https://www.jibbow.com/posts/criterion-flamegraphs/
@@ -18,7 +18,7 @@ fn bench(c: &mut Criterion) {
     c.bench_function("Fibonacci", |b| b.iter(|| fibonacci(black_box(20))));
 }
 
-criterion_group!{
+criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench

--- a/src/criterion.rs
+++ b/src/criterion.rs
@@ -42,10 +42,9 @@ impl<'a, 'b> Profiler for PProfProfiler<'a, 'b> {
             Output::Protobuf => ".pb",
         };
         let output_path = benchmark_dir.join(format!("{}{}", benchmark_id, ext));
-        let mut output_file = File::create(&output_path).expect(&format!(
-            "File system error while creating {}",
-            output_path.display()
-        ));
+        let mut output_file = File::create(&output_path).unwrap_or_else(|_| {
+            panic!("File system error while creating {}", output_path.display())
+        });
 
         if let Some(profiler) = self.active_profiler.take() {
             match &mut self.output {

--- a/src/criterion.rs
+++ b/src/criterion.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+#[cfg(feature = "protobuf")]
+use crate::protos::Message;
+use crate::ProfilerGuard;
+use criterion::profiler::Profiler;
+
+use std::fs::File;
+use std::io::Write;
+use std::os::raw::c_int;
+use std::path::Path;
+
+pub enum Output {
+    #[cfg(feature = "flamegraph")]
+    FlameGraph,
+
+    #[cfg(feature = "protobuf")]
+    Protobuf,
+}
+
+pub struct PProfProfiler<'a> {
+    frequency: c_int,
+    output: Output,
+    active_profiler: Option<ProfilerGuard<'a>>,
+}
+
+impl<'a> Profiler for PProfProfiler<'a> {
+    fn start_profiling(&mut self, _benchmark_id: &str, _benchmark_dir: &Path) {
+        self.active_profiler = Some(ProfilerGuard::new(self.frequency).unwrap());
+    }
+
+    fn stop_profiling(&mut self, benchmark_id: &str, benchmark_dir: &Path) {
+        std::fs::create_dir_all(benchmark_dir).unwrap();
+
+        let ext = match self.output {
+            #[cfg(feature = "flamegraph")]
+            Output::FlameGraph => ".svg",
+            #[cfg(feature = "protobuf")]
+            Output::Protobuf => ".pb",
+        };
+        let output_path = benchmark_dir.join(format!("{}{}", benchmark_id, ext));
+        let mut output_file = File::create(&output_path).expect(&format!(
+            "File system error while creating {}",
+            output_path.display()
+        ));
+
+        if let Some(profiler) = self.active_profiler.take() {
+            match self.output {
+                #[cfg(feature = "flamegraph")]
+                Output::FlameGraph => {
+                    profiler
+                        .report()
+                        .build()
+                        .unwrap()
+                        .flamegraph(output_file)
+                        .expect("Error while writing flamegraph");
+                }
+
+                #[cfg(feature = "protobuf")]
+                Output::Protobuf => {
+                    let profile = profiler.report().build().unwrap().pprof().unwrap();
+
+                    let mut content = Vec::new();
+                    profile
+                        .encode(&mut content)
+                        .expect("Error while encoding protobuf");
+
+                    output_file
+                        .write_all(&content)
+                        .expect("Error while writing protobuf");
+                }
+            }
+        }
+    }
+}

--- a/src/criterion.rs
+++ b/src/criterion.rs
@@ -30,7 +30,7 @@ pub struct PProfProfiler<'a, 'b> {
 
 impl<'a, 'b> PProfProfiler<'a, 'b> {
     pub fn new(frequency: c_int, output: Output<'b>) -> Self {
-        return Self {
+        Self {
             frequency,
             output,
             active_profiler: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,5 @@ pub mod protos {
     include!(concat!(env!("OUT_DIR"), "/perftools.profiles.rs"));
 }
 
-#[cfg(feature = "flamegraph")]
+#[cfg(feature = "criterion")]
 pub mod criterion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 //!    println!("report: {:?}", &report);
 //!};
 //! ```
+//! 
+//! You can find more details in [README.md](https://github.com/tikv/pprof-rs/blob/master/README.md)
 
 /// Define the MAX supported stack depth. TODO: make this variable mutable.
 pub const MAX_DEPTH: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,3 +49,6 @@ pub mod protos {
 
     include!(concat!(env!("OUT_DIR"), "/perftools.profiles.rs"));
 }
+
+#[cfg(feature = "flamegraph")]
+pub mod criterion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!    println!("report: {:?}", &report);
 //!};
 //! ```
-//! 
+//!
 //! You can find more details in [README.md](https://github.com/tikv/pprof-rs/blob/master/README.md)
 
 /// Define the MAX supported stack depth. TODO: make this variable mutable.


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

In this PR, I provide an implementation of `criterion::Profiler` in the `pprof-rs`, so that the users of `pprof-rs` and `criterion` would be easier to integrate and benefit from them.

Inspired by criterion, maybe we can generate [Differential Flame Graphs](http://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html) for two benchmarks in the future, which would be really awesome (though `criterion` doesn't support it yet).