### PR TITLE
Bump version to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pprof"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
As the `prost` bumps to a new version and the `pprof-rs` exports the `Message` of `prost`, we need to bump the version.

Signed-off-by: YangKeao <yangkeao@chunibyo.icu>