### PR TITLE
Add thread names and timing information to protobuf reports

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -159,6 +159,17 @@ pub struct Frames {
     pub thread_id: u64,
 }
 
+impl Frames {
+    /// Returns a thread identifier (name or ID) as a string.
+    pub fn thread_name_or_id(&self) -> String {
+        if !self.thread_name.is_empty() {
+            self.thread_name.clone()
+        } else {
+            format!("{:?}", self.thread_id)
+        }
+    }
+}
+
 impl From<UnresolvedFrames> for Frames {
     fn from(frames: UnresolvedFrames) -> Self {
         let mut fs = Vec::new();

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -134,7 +134,10 @@ impl ProfilerGuard<'_> {
 
     /// Generate a report
     pub fn report(&self) -> ReportBuilder {
-        ReportBuilder::new(self.profiler)
+        ReportBuilder::new(
+            self.profiler,
+            self.timer.as_ref().map(Timer::timing).unwrap_or_default(),
+        )
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::time::SystemTime;
 
 use parking_lot::RwLock;
 
@@ -215,6 +214,7 @@ mod protobuf {
     use super::*;
     use crate::protos;
     use std::collections::HashSet;
+    use std::time::SystemTime;
 
     const SAMPLES: &str = "samples";
     const COUNT: &str = "count";

--- a/src/report.rs
+++ b/src/report.rs
@@ -303,7 +303,6 @@ mod protobuf {
                         *count as i64 * 1_000_000_000 / self.timing.frequency as i64,
                     ],
                     label: vec![thread_name],
-                    ..protos::Sample::default()
                 };
                 samples.push(sample);
             }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,6 +2,7 @@
 
 use std::os::raw::c_int;
 use std::ptr::null_mut;
+use std::time::{Duration, Instant, SystemTime};
 
 #[repr(C)]
 #[derive(Clone)]
@@ -24,7 +25,9 @@ extern "C" {
 const ITIMER_PROF: c_int = 2;
 
 pub struct Timer {
-    _frequency: c_int,
+    pub frequency: c_int,
+    pub start_time: SystemTime,
+    pub start_instant: Instant,
 }
 
 impl Timer {
@@ -48,7 +51,19 @@ impl Timer {
         };
 
         Timer {
-            _frequency: frequency,
+            frequency,
+            start_time: SystemTime::now(),
+            start_instant: Instant::now(),
+        }
+    }
+
+    /// Returns a `ReportTiming` struct having this timer's frequency and start
+    /// time; and the time elapsed since its creation as duration.
+    pub fn timing(&self) -> ReportTiming {
+        ReportTiming {
+            frequency: self.frequency,
+            start_time: self.start_time,
+            duration: self.start_instant.elapsed(),
         }
     }
 }
@@ -70,5 +85,26 @@ impl Drop for Timer {
                 null_mut(),
             )
         };
+    }
+}
+
+/// Timing metadata for a collected report.
+#[derive(Clone)]
+pub struct ReportTiming {
+    /// Frequency at which samples were collected.
+    pub frequency: i32,
+    /// Collection start time.
+    pub start_time: SystemTime,
+    /// Collection duration.
+    pub duration: Duration,
+}
+
+impl Default for ReportTiming {
+    fn default() -> Self {
+        Self {
+            frequency: 1,
+            start_time: SystemTime::UNIX_EPOCH,
+            duration: Default::default(),
+        }
     }
 }


### PR DESCRIPTION
Record thread names (or IDs); record "cpu: nanoseconds" in addition to
"samples: count" value types; and the timestamp and duration of the collected
profile; to protobuf reports.

This matches exactly the format of profiles produced by Golang's
`runtime/pprof` package. And, when inspected with `go tool pprof` default to
displaying seconds spent in a specific location, as opposed to samples (whose
counts depend on sampling frequency, requiring a lot of mental math to map to
actual time). It is of course still possible to view samples instead of
seconds, if wanted.

Signed-off-by: Alin Sinpalean <alin.sinpalean@gmail.com>