### PR TITLE
migrate to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pprof"
 version = "0.6.1"
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "An internal perf tools for rust programs."
 repository = "https://github.com/tikv/pprof-rs"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -316,7 +316,7 @@ mod tests {
         }
 
         stack_hash_counter.iter().for_each(|entry| {
-            test_utils::add_map(&mut real_map, &entry);
+            test_utils::add_map(&mut real_map, entry);
         });
 
         for item in 0..(1 << 10) * 4 {
@@ -344,7 +344,7 @@ mod tests {
         }
 
         collector.try_iter().unwrap().for_each(|entry| {
-            test_utils::add_map(&mut real_map, &entry);
+            test_utils::add_map(&mut real_map, entry);
         });
 
         for item in 0..(1 << 12) * 4 {
@@ -416,11 +416,11 @@ mod malloc_free_test {
         }
 
         FLAG.with(|flag| {
-            assert_eq!(*flag.borrow(), false);
+            assert!(!*flag.borrow());
         });
 
         collector.try_iter().unwrap().for_each(|entry| {
-            test_utils::add_map(&mut real_map, &entry);
+            test_utils::add_map(&mut real_map, entry);
         });
 
         for item in 0..(1 << 10) * 4 {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -421,8 +421,8 @@ mod tests {
             }
         }
         let mut prime_numbers = vec![];
-        for i in 2..10000 {
-            if prime_number_table[i] {
+        for (i, item) in prime_number_table.iter().enumerate().skip(2) {
+            if *item {
                 prime_numbers.push(i);
             }
         }
@@ -452,7 +452,7 @@ mod tests {
         }
 
         FLAG.with(|flag| {
-            assert_eq!(*flag.borrow(), false);
+            assert!(!*flag.borrow());
         });
     }
 }


### PR DESCRIPTION
- migrate to 2021 edition
- fix clippy

Signed-off-by: Chojan Shang <psiace@outlook.com>