### PR TITLE
add allow(clippy::large_enum_variant) to Output

### DIFF
--- a/src/criterion.rs
+++ b/src/criterion.rs
@@ -15,6 +15,7 @@ use std::marker::PhantomData;
 use std::os::raw::c_int;
 use std::path::Path;
 
+#[allow(clippy::large_enum_variant)]
 pub enum Output<'a> {
     #[cfg(feature = "flamegraph")]
     Flamegraph(Option<FlamegraphOptions<'a>>),


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

```rust
pub enum Output<'a> {
    #[cfg(feature = "flamegraph")]
    Flamegraph(Option<FlamegraphOptions<'a>>),

    #[cfg(feature = "protobuf")]
    Protobuf,

    #[deprecated(
        note = "This branch is used to include lifetime parameter. Don't use it directly."
    )]
    _Phantom(PhantomData<&'a ()>),
}
```

```
Error:   --> src/criterion.rs:20:5
   |
20 |     Flamegraph(Option<FlamegraphOptions<'a>>),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this variant is 296 bytes
   |
   = note: `-D clippy::large-enum-variant` implied by `-D warnings`
note: and the second-largest variant is 0 bytes:
  --> src/criterion.rs:23:5
   |
23 |     Protobuf,
   |     ^^^^^^^^
   = help: for further information visit rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
20 |     Flamegraph(Box<Option<FlamegraphOptions<'a>>>),
   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The first variant `Output::Flamegraph` is too long, but I think it's acceptable. This clippy rule blocks #90 .