### PR TITLE
add rust 1.56.0 to the ci matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly, 1.56.1]
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+        exclude:
+        - os: ubuntu-latest
+          target: x86_64-apple-darwin
+        - os: ubuntu-latest
+          target: aarch64-apple-darwin
+        - os: macos-latest
+          target: x86_64-unknown-linux-gnu
+        - os: macos-latest
+          target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly]
+        toolchain: [stable, nightly, 1.56.0]
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly, 1.56.0]
+        toolchain: [stable, nightly, 1.56.1]
         target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
According to https://github.com/tikv/pprof-rs/pull/101 , we'd better check the compatibility with 1.56.1 rust.

Signed-off-by: YangKeao <yangkeao@chunibyo.icu>