### PR TITLE
profiler: Fix pthread_getname_np not available on musl

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -181,12 +181,12 @@ fn write_thread_name_fallback(current_thread: libc::pthread_t, name: &mut [libc:
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(all(any(target_os = "linux", target_os = "macos"), target_env = "gnu")))]
 fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
     write_thread_name_fallback(current_thread, name);
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(any(target_os = "linux", target_os = "macos"), target_env = "gnu"))]
 fn write_thread_name(current_thread: libc::pthread_t, name: &mut [libc::c_char]) {
     let name_ptr = name as *mut [libc::c_char] as *mut libc::c_char;
     let ret = unsafe { libc::pthread_getname_np(current_thread, name_ptr, MAX_THREAD_NAME) };


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

Fix https://github.com/tikv/pprof-rs/issues/41

This PR will make `pprof-rs` compilable on `x86_64-unknown-linux-musl`

```shell
:( PKG_CONFIG_ALLOW_CROSS=1 cargo build --target x86_64-unknown-linux-musl
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
```

Only tested on `linux` platform, please correct me if something is wrong.