### PR TITLE
Update nix to 0.24, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ backtrace = "0.3"
 once_cell = "1.9"
 libc = "^0.2.66"
 log = "0.4"
-nix = "0.23"
+nix = { version = "0.24", default-features = false, features = ["signal"] }
 parking_lot = "0.12"
 tempfile = "3.1"
 thiserror = "1.0"


### PR DESCRIPTION
Limiting features removes memoffset as an indirect dependency, and should slightly decrease compilation times.