### PR TITLE
Optimize mutually exclusive features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
 - Remove `backtrace-rs` feature, as the default choice when not specified (#130)
 
 ## [0.9.1] - 2022-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove `backtrace-rs` feature, as the default choice when not specified (#130)
+
 ## [0.9.1] - 2022-05-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,18 @@ documentation = "https://docs.rs/pprof/"
 readme = "README.md"
 
 [features]
-default = ["cpp", "backtrace-rs"]
+default = ["cpp"]
+cpp = ["symbolic-demangle/cpp"]
 flamegraph = ["inferno"]
+frame-pointer = []
 
 # A private feature to indicate either prost-codec or protobuf-codec is enabled.
 _protobuf = []
 prost-codec = ["prost", "prost-derive", "prost-build", "_protobuf"]
 protobuf-codec = ["protobuf", "protobuf-codegen-pure", "_protobuf"]
 
-backtrace-rs = ["backtrace"]
-frame-pointer = ["backtrace"]
-
-cpp = ["symbolic-demangle/cpp"]
-
 [dependencies]
-backtrace = { version = "0.3", optional = true }
+backtrace = { version = "0.3" }
 once_cell = "1.9"
 libc = "^0.2.66"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ FRAME: backtrace::backtrace::trace::h3e91a3123a3049a5 -> FRAME: pprof::profiler:
 - `flamegraph` enables the flamegraph report format.
 - `prost-codec` enables the pprof protobuf report format through `prost`.
 - `protobuf-codec` enables the pprof protobuf report format through `protobuf` crate.
-- `backtrace-rs` unwind the backtrace through `backtrace-rs` (which calls the `Unwind_Backtrace`).
 - `frame-pointer` gets the backtrace through frame pointer. **only available for nightly**
 
 ## Flamegraph

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -44,9 +44,15 @@ pub trait Trace {
         Self: Sized;
 }
 
-#[cfg(feature = "backtrace-rs")]
+#[cfg(not(all(
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    feature = "frame-pointer"
+)))]
 mod backtrace_rs;
-#[cfg(feature = "backtrace-rs")]
+#[cfg(not(all(
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    feature = "frame-pointer"
+)))]
 pub use backtrace_rs::Trace as TraceImpl;
 
 #[cfg(all(


### PR DESCRIPTION
In general, using mutually exclusive features will cause some trouble in downstream. Some reasons can be found here: https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features

Signed-off-by: mornyx <mornyx.z@gmail.com>