### PR TITLE
Export UnresolvedReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Remove `backtrace-rs` feature, as the default choice when not specified (#130)
 
+### Fixed
+- Export `UnresolvedReport` type to allow developers to get the unresolved report (#132)
+
 ## [0.9.1] - 2022-05-19
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::collector::{Collector, HashCounter};
 pub use self::error::{Error, Result};
 pub use self::frames::{Frames, Symbol};
 pub use self::profiler::{ProfilerGuard, ProfilerGuardBuilder};
-pub use self::report::{Report, ReportBuilder};
+pub use self::report::{Report, ReportBuilder, UnresolvedReport};
 
 #[cfg(feature = "flamegraph")]
 pub use inferno::flamegraph;


### PR DESCRIPTION
This let the user the option to get an unsymbolicated report.

Useful when the user is not interested in symbolication on the client. 

Thanks to this is possible to collect the absolute addresses (frame instruction pointer) instead of the relative address crafted by `resolve_symbol`.

With this absolute address is then possible to run symbolication as a separate process with the support of the debug symbol files if needed.