### PR TITLE
Adds timing info to each sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `backtrace-rs` feature, as the default choice when not specified (#130)
 
 ### Added
-- Add `sample_timestamp` to Frames and UnresolvedFrames in order to have more fine-grained info on when the samples are collected
+- Add `sample_timestamp` to Frames and UnresolvedFrames in order to have more fine-grained info on when the samples are collected (#133)
 
 ## [0.9.1] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Remove `backtrace-rs` feature, as the default choice when not specified (#130)
 
+### Added
+- Add `sample_timestamp` to Frames and UnresolvedFrames in order to have more fine-grained info on when the samples are collected
+
 ## [0.9.1] - 2022-05-19
 
 ### Fixed

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::os::raw::c_void;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 use smallvec::SmallVec;
 use symbolic_demangle::demangle;
@@ -18,6 +19,7 @@ pub struct UnresolvedFrames {
     pub thread_name: [u8; MAX_THREAD_NAME],
     pub thread_name_length: usize,
     pub thread_id: u64,
+    pub sample_timestamp: SystemTime,
 }
 
 impl Default for UnresolvedFrames {
@@ -28,6 +30,7 @@ impl Default for UnresolvedFrames {
             thread_name: [0; MAX_THREAD_NAME],
             thread_name_length: 0,
             thread_id: 0,
+            sample_timestamp: SystemTime::now(),
         }
     }
 }
@@ -43,6 +46,7 @@ impl UnresolvedFrames {
         frames: SmallVec<[<TraceImpl as Trace>::Frame; MAX_DEPTH]>,
         tn: &[u8],
         thread_id: u64,
+        sample_timestamp: SystemTime,
     ) -> Self {
         let thread_name_length = tn.len();
         let mut thread_name = [0; MAX_THREAD_NAME];
@@ -53,6 +57,7 @@ impl UnresolvedFrames {
             thread_name,
             thread_name_length,
             thread_id,
+            sample_timestamp,
         }
     }
 }
@@ -164,6 +169,7 @@ pub struct Frames {
     pub frames: Vec<Vec<Symbol>>,
     pub thread_name: String,
     pub thread_id: u64,
+    pub sample_timestamp: SystemTime,
 }
 
 impl Frames {
@@ -210,6 +216,7 @@ impl From<UnresolvedFrames> for Frames {
             thread_name: String::from_utf8_lossy(&frames.thread_name[0..frames.thread_name_length])
                 .into_owned(),
             thread_id: frames.thread_id,
+            sample_timestamp: frames.sample_timestamp,
         }
     }
 }


### PR DESCRIPTION
At the moment we only have timing info at `Report` level. We don't have more fine grained timing info for the samples collected.

This PR aims at adding timing info (`sample_timestamp`) to the samples collected.