### PR TITLE
feat: Fix and cover tests for target x86_64-unknown-linux-musl 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,10 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        name: Install musl
+        run: sudo apt install musl-tools
+
       - name: Run cargo test prost
         uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,20 +102,14 @@ jobs:
         toolchain: [stable, nightly]
         target: [
           x86_64-unknown-linux-gnu,
-          aarch64-unknown-linux-gnu,
           x86_64-unknown-linux-musl,
           x86_64-apple-darwin,
-          aarch64-apple-darwin,
         ]
         exclude:
           - os: ubuntu-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
           - os: macos-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -129,6 +129,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
           override: true
 
       - name: Run cargo test prost

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,16 +43,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly, 1.56.1]
-        target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin]
+        target: [
+          x86_64-unknown-linux-gnu,
+          aarch64-unknown-linux-gnu,
+          x86_64-unknown-linux-musl,
+          x86_64-apple-darwin,
+          aarch64-apple-darwin,
+        ]
         exclude:
-        - os: ubuntu-latest
-          target: x86_64-apple-darwin
-        - os: ubuntu-latest
-          target: aarch64-apple-darwin
-        - os: macos-latest
-          target: x86_64-unknown-linux-gnu
-        - os: macos-latest
-          target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -92,6 +100,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly]
+        target: [
+          x86_64-unknown-linux-gnu,
+          aarch64-unknown-linux-gnu,
+          x86_64-unknown-linux-musl,
+          x86_64-apple-darwin,
+          aarch64-apple-darwin,
+        ]
+        exclude:
+          - os: ubuntu-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -109,10 +135,10 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --features flamegraph,prost-codec
+          args: --features flamegraph,prost-codec --target ${{ matrix.target }}
 
       - name: Run cargo test protobuf
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --features flamegraph,protobuf-codec
+          args: --features flamegraph,protobuf-codec --target ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,10 @@ on: [push, pull_request]
 
 name: build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Format and Clippy

--- a/examples/malloc_hook.rs
+++ b/examples/malloc_hook.rs
@@ -5,13 +5,13 @@ extern crate libc;
 use pprof;
 use std::ffi::c_void;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 #[allow(clippy::wrong_self_convention)]
 #[allow(non_upper_case_globals)]
 static mut __malloc_hook: Option<extern "C" fn(size: usize) -> *mut c_void> = None;
 
 extern "C" {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     static mut __malloc_hook: Option<extern "C" fn(size: usize) -> *mut c_void>;
 
     fn malloc(size: usize) -> *mut c_void;

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -369,8 +369,13 @@ mod malloc_free_test {
     use std::collections::BTreeMap;
     use std::ffi::c_void;
 
+    #[cfg(not(target_env = "gnu"))]
+    #[allow(clippy::wrong_self_convention)]
+    #[allow(non_upper_case_globals)]
+    static mut __malloc_hook: Option<extern "C" fn(size: usize) -> *mut c_void> = None;
+
     extern "C" {
-        #[cfg(target_os = "linux")]
+        #[cfg(target_env = "gnu")]
         static mut __malloc_hook: Option<extern "C" fn(size: usize) -> *mut c_void>;
 
         fn malloc(size: usize) -> *mut c_void;


### PR DESCRIPTION
This PR addresses the following problems:

- Tests and examples not compilable under `x86_64-unknown-linux-musl`
- Add tests in GitHub actions so that all PRs are covered.