### PR TITLE
fix: increase stack max depth at 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `MAX_DEPTH` to 128
+
 ## [0.10.0] - 2022-06-27
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! [README.md](https://github.com/tikv/pprof-rs/blob/master/README.md)
 
 /// Define the MAX supported stack depth. TODO: make this variable mutable.
-pub const MAX_DEPTH: usize = 32;
+pub const MAX_DEPTH: usize = 128;
 
 /// Define the MAX supported thread name length. TODO: make this variable mutable.
 pub const MAX_THREAD_NAME: usize = 16;


### PR DESCRIPTION
At the moment `MAX_DEPTH` is set to 32.

This is a bit low as a value and in some cases important frames are cut out of the final result.