### PR TITLE
ignore prost mod and fix clippy warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub use self::report::{Report, ReportBuilder, UnresolvedReport};
 #[cfg(feature = "flamegraph")]
 pub use inferno::flamegraph;
 
+#[allow(clippy::all)]
 #[cfg(all(feature = "prost-codec", not(feature = "protobuf-codec")))]
 pub mod protos {
     pub use prost::Message;


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

1. I fix the clippy warning according to the instruction
2. Allow all clippy warning in the prost mod.