### PR TITLE
Bump version to v0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pprof"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

It's a mistake. I don't know why the former commit doesn't bump the version in Cargo.toml. I did it in this PR.