### PR TITLE
Restart syscalls interrupted by SIGPROF when possible

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -374,7 +374,9 @@ impl Profiler {
         let handler = signal::SigHandler::SigAction(perf_signal_handler);
         let sigaction = signal::SigAction::new(
             handler,
-            signal::SaFlags::SA_SIGINFO,
+            // SA_RESTART will only restart a syscall when it's safe to do so,
+            // e.g. when it's a blocking read(2) or write(2). See man 7 signal.
+            signal::SaFlags::SA_SIGINFO | signal::SaFlags::SA_RESTART,
             signal::SigSet::empty(),
         );
         unsafe { signal::sigaction(signal::SIGPROF, &sigaction) }?;


### PR DESCRIPTION
This is more convenient, because one would no longer need to check for `EINTR` in certain places. Of course, there's a bunch of syscalls like `epoll` which may still return `EINTR`, but at least pprof will be less likely to break sloppy code.