### PR TITLE
Only do per-frame-blocklist-check when frame-pointer is enabled

### DIFF
--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -12,7 +12,7 @@ use smallvec::SmallVec;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use findshlibs::{Segment, SharedLibrary, TargetSharedLibrary};
 
-use crate::backtrace::{Frame, Trace, TraceImpl};
+use crate::backtrace::{Trace, TraceImpl};
 use crate::collector::Collector;
 use crate::error::{Error, Result};
 use crate::frames::UnresolvedFrames;
@@ -290,7 +290,7 @@ extern "C" fn perf_signal_handler(
             TraceImpl::trace(ucontext, |frame| {
                 #[cfg(feature = "frame-pointer")]
                 {
-                    let ip = Frame::ip(frame);
+                    let ip = crate::backtrace::Frame::ip(frame);
                     if profiler.is_blocklisted(ip) {
                         return false;
                     }

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -288,9 +288,12 @@ extern "C" fn perf_signal_handler(
 
             let sample_timestamp: SystemTime = SystemTime::now();
             TraceImpl::trace(ucontext, |frame| {
-                let ip = Frame::ip(frame);
-                if profiler.is_blocklisted(ip) {
-                    return false;
+                #[cfg(feature = "frame-pointer")]
+                {
+                    let ip = Frame::ip(frame);
+                    if profiler.is_blocklisted(ip) {
+                        return false;
+                    }
                 }
 
                 if index < MAX_DEPTH {


### PR DESCRIPTION
Signed-off-by: mornyx <mornyx.z@gmail.com>

# Related Issues

- https://github.com/tikv/pprof-rs/issues/157
- https://github.com/pingcap/tiflash/issues/6228
- https://github.com/risingwavelabs/risingwave/issues/4765

# Background

We introduced frame-pointer based stacktrace in https://github.com/tikv/pprof-rs/commit/567c5d01c9bd8deb9ccbe5515122d5aa9faef0ad. But we cannot guarantee that all shared libraries have frame pointers enabled, and performing stacktracing directly based on frame pointers is dangerous and may cause crash.

So, we provide some protection. In general, there are two means of protection: `addr_validate` and `blocklist`. `addr_validate` ensures that we do not try to access unreadable addresses, and `blocklist` helps us exclude stack frames belonging to specified shared libraries.

# Issue

But the commit above introduces a problem, here is a minimal reproduction:

```toml
# Issue since: pprof = { git = "https://github.com/tikv/pprof-rs.git", rev = "567c5d01c9bd8deb9ccbe5515122d5aa9faef0ad", default-features = false, features = ["flamegraph", "protobuf-codec"] }
pprof = { version = "0.10", default-features = false, features = ["flamegraph", "protobuf-codec"] }
```

```rust
use pprof::ProfilerGuardBuilder;
use std::fs::File;

fn main() {
    let g = ProfilerGuardBuilder::default()
        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
        .build()
        .unwrap();
    workload();
    g.report()
        .build()
        .unwrap()
        .flamegraph(File::create("/tmp/r.svg").unwrap())
        .unwrap();
}

fn workload() -> Vec<i32> {
    let mut rs = vec![];
    for _ in 0..100_000_000 {
        let mut v = vec![];
        for n in 100_000_000..0 {
            v.push(n);
        }
        v.sort();
        rs.push(v.iter().sum());
    }
    rs
}
```

To avoid deadlocks, we will block shared libraries like `libc`, `pthread`, etc, but this causes an additional problem. Let's see the generated svg:

![r2](https://user-images.githubusercontent.com/40526986/199666204-bf47a3a2-5835-4a3b-8d1c-32638d3afc9b.svg)

It only contains samples inside the signal handler, all stack frames before the signal frame are lost.

# Reason

![ac2cace5-c2be-4c4d-8723-d28c4c21b85e](https://user-images.githubusercontent.com/40526986/199666770-23daed64-4dce-42f1-9f99-0bdcaa67641c.jpeg)

The code in the **RED BOX** is newly introduced by the commit above, with frame-pointer based stacktracing. Its purpose is to do extra protection in the callback of each stack frame. But when doing stacktraces with `backtrace-rs`, there are some magical dependencies on `libc` in order to handle signal frames on the stack. So they are blocked due to the existence of blocklist.

But why does it works well with `frame-pointer` feature? Because frame-pointer based stacktracing starts from `ucontext` provided by OS kernel, which is an argument of `perf_signal_handler`. `ucontext` holds the top stack frame before SIGPROF triggered, so we don't have to deal with signal frames at all.

# Solve

Only do per-frame-blocklist-check when `frame-pointer` is enabled. We will get the correct flamegraph:

![r](https://user-images.githubusercontent.com/40526986/199668782-2b48ee35-d6c7-412a-8488-8da25c294cb8.svg)
