### PR TITLE
Update `nix` from `0.24` to `0.26.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ backtrace = { version = "0.3" }
 once_cell = "1.9"
 libc = "^0.2.66"
 log = "0.4"
-nix = { version = "0.24", default-features = false, features = ["signal", "fs"] }
+nix = { version = "0.26.1", default-features = false, features = ["signal", "fs"] }
 parking_lot = "0.12"
 tempfile = "3.1"
 thiserror = "1.0"


### PR DESCRIPTION
Bumps `nix` to the latest version.