### PR TITLE
Replace TmpFdArray with Ring to remove dependency on tmpfs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ libc = "^0.2.66"
 log = "0.4"
 nix = { version = "0.26", default-features = false, features = ["signal", "fs"] }
 parking_lot = "0.12"
-tempfile = "3.1"
 thiserror = "1.0"
 findshlibs = "0.10"
 cfg-if = "1.0"


### PR DESCRIPTION
Hello 👋 This PR removes the tmpfs backing storage to the `temp_array`, replacing it with a LIFO ring buffer. The motivation behind this change is that in Kubernetes, by default your container is running in a read only filesystem, so if you want to be able to use it without requiring that each container their own tmpfs, we need to remove the usage of the temporary file. I'd be open to making a followup adding it back as an optional feature if it's important to keep the tmpfs storage for some platforms, but I think an entirely memory based profiler by default is more intuitive.