### PR TITLE
Enhance threads stacks collection and sampling frequency on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Cargo.lock
 #Cargo.lock
 
 .idea
+
+.devcontainer/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,10 @@ backtrace = { version = "0.3" }
 once_cell = "1.9"
 libc = "^0.2.66"
 log = "0.4"
-nix = { version = "0.26", default-features = false, features = ["signal", "fs"] }
+nix = { version = "0.26", default-features = false, features = [
+    "signal",
+    "fs",
+] }
 parking_lot = "0.12"
 tempfile = "3.1"
 thiserror = "1.0"
@@ -33,11 +36,17 @@ findshlibs = "0.10"
 cfg-if = "1.0"
 smallvec = "1.7"
 
-inferno = { version = "0.11", default-features = false, features = ["nameattr"], optional = true }
+inferno = { version = "0.11", default-features = false, features = [
+    "nameattr",
+], optional = true }
 prost = { version = "0.11", optional = true }
 prost-derive = { version = "0.11", optional = true }
 protobuf = { version = "2.0", optional = true }
-criterion = {version = "0.4", optional = true}
+criterion = { version = "0.4", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+errno = { version = "0.2.8" }
+thread-priority = { version = "0.10.0" }
 
 [dependencies.symbolic-demangle]
 version = "10.1"


### PR DESCRIPTION
This PR tries to address inconsistencies regarding the collection of samples across time and threads (somehow related to #177).

Currently to collect a sample (stack) we rely on the `SIGPROF` signal, which is a _**standard**_ signal. This has the following two limitations:

1. for standard signal, the set of pending signals is only a mask, meaning that, if multiple instances of a standard signal are generated while that signal is blocked, then only one instance of the signal is marked as pending (and the signal will be delivered just once when it is unblocked)
2. the `SIGPROF` signal is directed to the process and will then be handled by one of the thread, hence we'll only collect the stack for the thread that in a given moment is "handling" the signal.


The changes in this PR try to address both of the above mentioned limitations by making use of `real-time` signals and `per-thread` delivery.

### Real-Time Signal 

An important distinction here is that real-time signals are queued. If multiple instances of a realtime signal are sent to a process, then the signal is delivered multiple times (hence we're not going to waste a potential "sampling round").


### per-thread delivery

Instead of having a timer that will generate a `SIGPROF` signal that will be handled by a signal, we propose having an external thread which, with a given frequency, collects the `tid` (kernel thread id) of the running threads and send the real-time signal to each one of them. 