### PR TITLE
validate whether addr is null before constructing slice

### DIFF
--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -59,6 +59,10 @@ fn open_pipe() -> nix::Result<()> {
 }
 
 pub fn validate(addr: *const libc::c_void) -> bool {
+    if addr.is_null() {
+        return false;
+    }
+
     const CHECK_LENGTH: usize = 2 * size_of::<*const libc::c_void>() / size_of::<u8>();
 
     // read data in the pipe

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -37,7 +37,7 @@ pub struct Bucket<T: 'static> {
 
 impl<T: Eq + Default> Default for Bucket<T> {
     fn default() -> Bucket<T> {
-        let entries = Box::new(Default::default());
+        let entries = Box::default();
 
         Self { length: 0, entries }
     }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -18,7 +18,7 @@ pub struct UnresolvedFrames {
     pub frames: SmallVec<[<TraceImpl as Trace>::Frame; MAX_DEPTH]>,
     pub thread_name: [u8; MAX_THREAD_NAME],
     pub thread_name_length: usize,
-    pub thread_id: u64,
+    pub thread_id: libc::pthread_t,
     pub sample_timestamp: SystemTime,
 }
 
@@ -45,7 +45,7 @@ impl UnresolvedFrames {
     pub fn new(
         frames: SmallVec<[<TraceImpl as Trace>::Frame; MAX_DEPTH]>,
         tn: &[u8],
-        thread_id: u64,
+        thread_id: libc::pthread_t,
         sample_timestamp: SystemTime,
     ) -> Self {
         let thread_name_length = tn.len();
@@ -168,7 +168,7 @@ impl Hash for Symbol {
 pub struct Frames {
     pub frames: Vec<Vec<Symbol>>,
     pub thread_name: String,
-    pub thread_id: u64,
+    pub thread_id: libc::pthread_t,
     pub sample_timestamp: SystemTime,
 }
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -358,7 +358,7 @@ extern "C" fn perf_signal_handler(
             write_thread_name(current_thread, &mut name);
 
             let name = unsafe { std::ffi::CStr::from_ptr(name_ptr) };
-            profiler.sample(bt, name.to_bytes(), current_thread as u64, sample_timestamp);
+            profiler.sample(bt, name.to_bytes(), current_thread, sample_timestamp);
         }
     }
 }
@@ -455,7 +455,7 @@ impl Profiler {
         &mut self,
         backtrace: SmallVec<[<TraceImpl as Trace>::Frame; MAX_DEPTH]>,
         thread_name: &[u8],
-        thread_id: u64,
+        thread_id: libc::pthread_t,
         sample_timestamp: SystemTime,
     ) {
         let frames = UnresolvedFrames::new(backtrace, thread_name, thread_id, sample_timestamp);

--- a/src/report.rs
+++ b/src/report.rs
@@ -229,7 +229,7 @@ mod protobuf {
         /// `pprof` will generate google's pprof format report.
         pub fn pprof(&self) -> crate::Result<protos::Profile> {
             let mut dedup_str = HashSet::new();
-            for key in self.data.iter().map(|(key, _)| key) {
+            for key in self.data.keys() {
                 dedup_str.insert(key.thread_name_or_id());
                 for frame in key.frames.iter() {
                     for symbol in frame {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

Validate whether the address is null before trying to construct the slice. Because in debug build, the `from_raw_parts` will check whether the addr is null and aligned, if not, it will panic.

The embarrasing part is that this problem cannot be reproduced through test, so the current test cannot cover this situation...