### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.1] - 2023-02-21
+
+### Added
+- Support RISC-V architecture (#169)
+- Support LoongArch64 architecture (#174)
+
+### Fixed
+- Use a globally shared pipe to validate memory to avoid FD leak (#198)
 
 ## [0.11.0] - 2022-11-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pprof"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Yang Keao <keao.yang@yahoo.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This version includes the following change:

1. Add support for RISC-V and LoongArch64
2. Fix the FD leak caused by thread local pipe which is used to validate address
