### PR TITLE
Bump the MSRV to 1.64.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Check if the prost file committed to git is up-to-date
         run: |
-          mv Cargo.toml.bak Cargo.toml
           git diff --no-ext-diff --exit-code
 
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: 1.56.1
+          toolchain: 1.64.0
           override: true
           components: rustfmt, clippy
-      
+
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
 
@@ -34,12 +34,6 @@ jobs:
 
       - name: Remove pre-generated prost files to force regeneration
         run: rm proto/*.rs
-
-      - name: Specify dependency version for old Rust
-        run: |
-          cp Cargo.toml Cargo.toml.bak
-          sed -i "s|inferno = { version = \"0.11\"|inferno = { version = \"=0.11.1\"|g" ./Cargo.toml
-          sed -i "s|criterion = \"0.4\"|criterion = \"=0.3.0\"\ncsv = \"=1.1.0\"|g" Cargo.toml
 
       - name: Run cargo clippy prost
         uses: actions-rs/cargo@v1.0.3
@@ -63,14 +57,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        toolchain: [stable, nightly, 1.56.1]
-        target: [
-          x86_64-unknown-linux-gnu,
-          aarch64-unknown-linux-gnu,
-          x86_64-unknown-linux-musl,
-          x86_64-apple-darwin,
-          aarch64-apple-darwin,
-        ]
+        toolchain: [stable, nightly, 1.64.0]
+        target:
+          [
+            x86_64-unknown-linux-gnu,
+            aarch64-unknown-linux-gnu,
+            x86_64-unknown-linux-musl,
+            x86_64-apple-darwin,
+            aarch64-apple-darwin,
+          ]
         exclude:
           - os: ubuntu-latest
             target: x86_64-apple-darwin
@@ -97,13 +92,6 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
-      - name: Specify dependency version for old Rust
-        if: ${{ matrix.toolchain == '1.56.1' }}
-        run: |
-          # sed -i is not compatible with Mac OS
-          mv Cargo.toml Cargo.toml.bak
-          sed "s|inferno = { version = \"0.11\"|inferno = { version = \"=0.11.1\"|g" Cargo.toml.bak > ./Cargo.toml
-
       - name: Run cargo build prost
         uses: actions-rs/cargo@v1.0.3
         with:
@@ -129,11 +117,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         toolchain: [stable, nightly]
-        target: [
-          x86_64-unknown-linux-gnu,
-          x86_64-unknown-linux-musl,
-          x86_64-apple-darwin,
-        ]
+        target:
+          [
+            x86_64-unknown-linux-gnu,
+            x86_64-unknown-linux-musl,
+            x86_64-apple-darwin,
+          ]
         exclude:
           - os: ubuntu-latest
             target: x86_64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "An internal perf tools for rust programs."
 repository = "https://github.com/tikv/pprof-rs"
 documentation = "https://docs.rs/pprof/"
 readme = "README.md"
+rust-version = "1.64.0"  # MSRV
 
 [features]
 default = ["cpp"]

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Unit tests have been added to guarantee there is no `malloc` in sample functions
 
 ## Minimum Supported Rust Version
 
-Rust 1.56 or higher.
+Rust 1.64 or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a minor version bump.
 


### PR DESCRIPTION
If the rust toolchain lower than v1.64.0 then you will get a compile error:
```rust
error[E0106]: missing lifetime specifier
  --> /Users/hi-rustin/.cargo/registry/src/github.com-1ecc6299db9ec823/inferno-0.11.15/src/flamegraph/color/mod.rs:83:25
   |
83 |     pub const VARIANTS: &[&'static str] = &[
   |                         ^ expected named lifetime parameter
   |
help: consider using the `'static` lifetime
   |
83 |     pub const VARIANTS: &'static [&'static str] = &[
   |                          +++++++
help: consider introducing a named lifetime parameter
   |
81 ~ impl<'a> Palette {
82 |     /// The valid set of palettes (via `FromStr`).
83 ~     pub const VARIANTS: &'a [&'static str] = &[
```