### PR TITLE
Correct required-features for profile_proto example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ required-features = ["flamegraph"]
 
 [[example]]
 name = "profile_proto"
-required-features = ["protobuf"]
+required-features = ["protobuf", "prost-codec"]
 
 [[example]]
 name = "multithread_flamegraph"


### PR DESCRIPTION
Before:
```console
➜  pprof-rs git:(master) ✗ cargo run --example profile_proto --features="protobuf"                            
    Blocking waiting for file lock on build directory
   Compiling pprof v0.11.1 (/Users/hi-rustin/vsc/pprof-rs)
error[E0432]: unresolved import `pprof::protos`
 --> examples/profile_proto.rs:3:12
  |
3 | use pprof::protos::Message;
  |            ^^^^^^ could not find `protos` in `pprof`

error[E0599]: no method named `pprof` found for struct `pprof::Report` in the current scope
   --> examples/profile_proto.rs:104:30
    |
104 |         let profile = report.pprof().unwrap();
    |                              ^^^^^ method not found in `pprof::Report`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `pprof` due to 2 previous errors
```
After:
```console
➜  pprof-rs git:(master) ✗ cargo run --example profile_proto                                                  
error: target `profile_proto` in package `pprof` requires the features: `protobuf`, `prost-codec`
Consider enabling them by passing, e.g., `--features="protobuf prost-codec"
```