### PR TITLE
Hide `perf_signal_handler` frames on macOS

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -197,10 +197,13 @@ impl From<UnresolvedFrames> for Frames {
                 symbols.push(symbol);
             });
 
-            if symbols
-                .iter()
-                .any(|symbol| symbol.name() == "perf_signal_handler")
-            {
+            if symbols.iter().any(|symbol| {
+                // macOS prepends an underscore even with `#[no_mangle]`
+                matches!(
+                    &*symbol.name(),
+                    "perf_signal_handler" | "_perf_signal_handler"
+                )
+            }) {
                 // ignore frame itself and its next one
                 frame_iter.next();
                 continue;


### PR DESCRIPTION
macOS always starts symbols with an additional underscore and `symbolic` doesn't remove it. Because of that the `perf_signal_handler` function can't currently be found by `pprof`, cluttering the flamegraph.