### PR TITLE
Splitting profile_proto example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,12 @@ name = "flamegraph"
 required-features = ["flamegraph"]
 
 [[example]]
-name = "profile_proto"
+name = "profile_proto_with_prost"
 required-features = ["protobuf", "prost-codec"]
+
+[[example]]
+name = "profile_proto_with_protobuf_codec"
+required-features = ["protobuf", "protobuf-codec"]
 
 [[example]]
 name = "multithread_flamegraph"

--- a/examples/profile_proto_with_prost.rs
+++ b/examples/profile_proto_with_prost.rs
@@ -104,10 +104,7 @@ fn main() {
         let profile = report.pprof().unwrap();
 
         let mut content = Vec::new();
-        #[cfg(not(feature = "protobuf-codec"))]
         profile.encode(&mut content).unwrap();
-        #[cfg(feature = "protobuf-codec")]
-        profile.write_to_vec(&mut content).unwrap();
         file.write_all(&content).unwrap();
 
         println!("report: {:?}", report);

--- a/examples/profile_proto_with_protobuf_codec.rs
+++ b/examples/profile_proto_with_protobuf_codec.rs
@@ -1,0 +1,112 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use pprof::protos::Message;
+use std::fs::File;
+use std::io::Write;
+
+#[inline(never)]
+fn is_prime_number1(v: usize, prime_numbers: &[usize]) -> bool {
+    if v < 10000 {
+        let r = prime_numbers.binary_search(&v);
+        return r.is_ok();
+    }
+
+    for n in prime_numbers {
+        if v % n == 0 {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[inline(always)]
+fn is_prime_number2(v: usize, prime_numbers: &[usize]) -> bool {
+    if v < 10000 {
+        let r = prime_numbers.binary_search(&v);
+        return r.is_ok();
+    }
+
+    for n in prime_numbers {
+        if v % n == 0 {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[inline(never)]
+fn is_prime_number3(v: usize, prime_numbers: &[usize]) -> bool {
+    if v < 10000 {
+        let r = prime_numbers.binary_search(&v);
+        return r.is_ok();
+    }
+
+    for n in prime_numbers {
+        if v % n == 0 {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[inline(never)]
+fn prepare_prime_numbers() -> Vec<usize> {
+    // bootstrap: Generate a prime table of 0..10000
+    let mut prime_number_table: [bool; 10000] = [true; 10000];
+    prime_number_table[0] = false;
+    prime_number_table[1] = false;
+    for i in 2..10000 {
+        if prime_number_table[i] {
+            let mut v = i * 2;
+            while v < 10000 {
+                prime_number_table[v] = false;
+                v += i;
+            }
+        }
+    }
+    let mut prime_numbers = vec![];
+    for (i, exist) in prime_number_table.iter().enumerate().skip(2) {
+        if *exist {
+            prime_numbers.push(i);
+        }
+    }
+    prime_numbers
+}
+
+fn main() {
+    let prime_numbers = prepare_prime_numbers();
+
+    let guard = pprof::ProfilerGuard::new(100).unwrap();
+
+    let mut v = 0;
+
+    for i in 2..5000000 {
+        if i % 4 == 0 {
+            if is_prime_number1(i, &prime_numbers) {
+                v += 1;
+            }
+        } else if i % 4 == 1 {
+            if is_prime_number2(i, &prime_numbers) {
+                v += 1;
+            }
+        } else if is_prime_number3(i, &prime_numbers) {
+            v += 1;
+        }
+    }
+
+    println!("Prime numbers: {}", v);
+
+    if let Ok(report) = guard.report().build() {
+        let mut file = File::create("profile.pb").unwrap();
+        let profile = report.pprof().unwrap();
+
+        let mut content = Vec::new();
+        profile.write_to_vec(&mut content).unwrap();
+        file.write_all(&content).unwrap();
+
+        println!("report: {:?}", report);
+    };
+}


### PR DESCRIPTION
In [this PR](https://github.com/tikv/pprof-rs/pull/206) I added the required features for the profile_proto example. But it is not correct. Because you can only specify one of them. So I think the right approach is to split it into two.