### PR TITLE
Remove useless features for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,11 +60,11 @@ required-features = ["flamegraph"]
 
 [[example]]
 name = "profile_proto_with_prost"
-required-features = ["protobuf", "prost-codec"]
+required-features = ["prost-codec"]
 
 [[example]]
 name = "profile_proto_with_protobuf_codec"
-required-features = ["protobuf", "protobuf-codec"]
+required-features = ["protobuf-codec"]
 
 [[example]]
 name = "multithread_flamegraph"


### PR DESCRIPTION
When I commented on this issue https://github.com/tikv/pprof-rs/issues/149. I found we added some useless features for our examples. 

I don't know why I didn't notice it last time. Sorry for changing this couple of times:(