### PR TITLE
chore(deps): bump criterion to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ inferno = { version = "0.11", default-features = false, features = ["nameattr"],
 prost = { version = "0.11", optional = true }
 prost-derive = { version = "0.11", optional = true }
 protobuf = { version = "2.0", optional = true }
-criterion = {version = "0.4", optional = true}
+criterion = {version = "0.5", optional = true}
 
 [dependencies.symbolic-demangle]
 version = "12.1"
@@ -46,7 +46,7 @@ default-features = false
 features = ["rust"]
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 rand = "0.8.0"
 
 [build-dependencies]


### PR DESCRIPTION
no breaking changes besides the msrv 1.64: https://github.com/bheisler/criterion.rs/blob/master/CHANGELOG.md


this also removes atty dependency that is unmaintained and has some security warnings