### PR TITLE
Change sc_pc to __pc for loongarch64

### DIFF
--- a/src/backtrace/frame_pointer.rs
+++ b/src/backtrace/frame_pointer.rs
@@ -77,7 +77,7 @@ impl super::Trace for Trace {
         let frame_pointer = unsafe { (*ucontext).uc_mcontext.__gregs[libc::REG_S0] as usize };
 
         #[cfg(all(target_arch = "loongarch64", target_os = "linux"))]
-        let frame_pointer = unsafe { (*ucontext).uc_mcontext.sc_regs[22] as usize };
+        let frame_pointer = unsafe { (*ucontext).uc_mcontext.__gregs[22] as usize };
 
         let mut frame_pointer = frame_pointer as *mut FramePointerLayout;
 

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -339,7 +339,7 @@ extern "C" fn perf_signal_handler(
                 let addr = unsafe { (*ucontext).uc_mcontext.__gregs[libc::REG_PC] as usize };
 
                 #[cfg(all(target_arch = "loongarch64", target_os = "linux"))]
-                let addr = unsafe { (*ucontext).uc_mcontext.sc_pc as usize };
+                let addr = unsafe { (*ucontext).uc_mcontext.__pc as usize };
 
                 if profiler.is_blocklisted(addr) {
                     return;


### PR DESCRIPTION
Hi,

I want to fix loongarch64 bindings as followed rust-lang/libc [loongarch64 mcontext_t __pc](https://github.com/rust-lang/libc/blob/main/src/unix/linux_like/linux/gnu/b64/loongarch64/align.rs#L20).

Thanks,
Leslie Zhai