### PR TITLE
fix: use T aligned pointer in TempFdArray

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -69,25 +69,29 @@ impl<'a> ReportBuilder<'a> {
                 Err(Error::CreatingError)
             }
             Ok(profiler) => {
-                profiler.data.try_iter()?.for_each(|entry| {
-                    let count = entry.count;
-                    if count > 0 {
-                        let key = &entry.item;
-                        match hash_map.get_mut(key) {
-                            Some(value) => {
-                                *value += count;
-                            }
-                            None => {
-                                match hash_map.insert(key.clone(), count) {
-                                    None => {}
-                                    Some(_) => {
-                                        unreachable!();
-                                    }
-                                };
+                let mut file_buffer_store = None;
+                profiler
+                    .data
+                    .try_iter(&mut file_buffer_store)?
+                    .for_each(|entry| {
+                        let count = entry.count;
+                        if count > 0 {
+                            let key = &entry.item;
+                            match hash_map.get_mut(key) {
+                                Some(value) => {
+                                    *value += count;
+                                }
+                                None => {
+                                    match hash_map.insert(key.clone(), count) {
+                                        None => {}
+                                        Some(_) => {
+                                            unreachable!();
+                                        }
+                                    };
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
                 Ok(UnresolvedReport {
                     data: hash_map,
@@ -107,29 +111,33 @@ impl<'a> ReportBuilder<'a> {
                 Err(Error::CreatingError)
             }
             Ok(profiler) => {
-                profiler.data.try_iter()?.for_each(|entry| {
-                    let count = entry.count;
-                    if count > 0 {
-                        let mut key = Frames::from(entry.item.clone());
-                        if let Some(processor) = &self.frames_post_processor {
-                            processor(&mut key);
-                        }
+                let mut file_buffer_store = None;
+                profiler
+                    .data
+                    .try_iter(&mut file_buffer_store)?
+                    .for_each(|entry| {
+                        let count = entry.count;
+                        if count > 0 {
+                            let mut key = Frames::from(entry.item.clone());
+                            if let Some(processor) = &self.frames_post_processor {
+                                processor(&mut key);
+                            }
 
-                        match hash_map.get_mut(&key) {
-                            Some(value) => {
-                                *value += count;
-                            }
-                            None => {
-                                match hash_map.insert(key, count) {
-                                    None => {}
-                                    Some(_) => {
-                                        unreachable!();
-                                    }
-                                };
+                            match hash_map.get_mut(&key) {
+                                Some(value) => {
+                                    *value += count;
+                                }
+                                None => {
+                                    match hash_map.insert(key, count) {
+                                        None => {}
+                                        Some(_) => {
+                                            unreachable!();
+                                        }
+                                    };
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
                 Ok(Report {
                     data: hash_map,


### PR DESCRIPTION
Fix for problem highlighted by #232.

I've observed app crash on my MacOS m1 machine with `frame-pointer` feature enabled due to unaligned pointer in `slice_from_raw_parts`.

Direct call to `alloc` is used to create properly aligned pointer.

`ManuallyDrop<T>` was used instead of `T` when creating `TempFdArrayIterator` to prevent use after drop since `try_iter` might be called more than once (not sure that strictly required since afaik `UnresolvedFrames` shouldn't allocate any memory).
