### PR TITLE
Add support for OpenBSD

### DIFF
--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -28,7 +28,7 @@ fn create_pipe() -> nix::Result<(i32, i32)> {
 }
 
 #[inline]
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
 fn create_pipe() -> nix::Result<(i32, i32)> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
     use nix::unistd::pipe;

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -248,6 +248,11 @@ impl ErrnoProtector {
                 let errno = *libc::__error();
                 Self(errno)
             }
+            #[cfg(target_os = "openbsd")]
+            {
+                let errno = *libc::__errno();
+                Self(errno)
+            }
         }
     }
 }
@@ -266,6 +271,10 @@ impl Drop for ErrnoProtector {
             #[cfg(any(target_os = "macos", target_os = "freebsd"))]
             {
                 *libc::__error() = self.0;
+            }
+            #[cfg(target_os = "openbsd")]
+            {
+                *libc::__errno() = self.0;
             }
         }
     }
@@ -306,6 +315,8 @@ extern "C" fn perf_signal_handler(
 
                 #[cfg(all(target_arch = "x86_64", target_os = "freebsd"))]
                 let addr = unsafe { (*ucontext).uc_mcontext.mc_rip as usize };
+                #[cfg(all(target_arch = "x86_64", target_os = "openbsd"))]
+                let addr = unsafe { (*ucontext).sc_rip as usize };
 
                 #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
                 let addr = unsafe {


### PR DESCRIPTION
This makes pprof-rs compile, but the generated flamegraphs are total garbage (at least for [fuse-ufs](https://github.com/realchonk/fuse-ufs)).