### PR TITLE
Add support for NetBSD/amd64

### DIFF
--- a/src/addr_validate.rs
+++ b/src/addr_validate.rs
@@ -28,7 +28,7 @@ fn create_pipe() -> nix::Result<(i32, i32)> {
 }
 
 #[inline]
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+#[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "netbsd"))]
 fn create_pipe() -> nix::Result<(i32, i32)> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
     use nix::unistd::pipe;

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -233,7 +233,7 @@ struct ErrnoProtector(libc::c_int);
 impl ErrnoProtector {
     fn new() -> Self {
         unsafe {
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "netbsd"))]
             {
                 let errno = *libc::__errno();
                 Self(errno)
@@ -255,7 +255,7 @@ impl ErrnoProtector {
 impl Drop for ErrnoProtector {
     fn drop(&mut self) {
         unsafe {
-            #[cfg(target_os = "android")]
+            #[cfg(any(target_os = "android", target_os = "netbsd"))]
             {
                 *libc::__errno() = self.0;
             }
@@ -304,8 +304,12 @@ extern "C" fn perf_signal_handler(
                 let addr =
                     unsafe { (*ucontext).uc_mcontext.gregs[libc::REG_RIP as usize] as usize };
 
-                #[cfg(all(target_arch = "x86_64", target_os = "freebsd"))]
+                #[cfg(target_os = "freebsd")]
                 let addr = unsafe { (*ucontext).uc_mcontext.mc_rip as usize };
+
+                #[cfg(all(target_arch = "x86_64", target_os = "netbsd"))]
+                let addr =
+                    unsafe { (*ucontext).uc_mcontext.__gregs[libc::_REG_RIP as usize] as usize };
 
                 #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
                 let addr = unsafe {
@@ -323,7 +327,7 @@ extern "C" fn perf_signal_handler(
                 ))]
                 let addr = unsafe { (*ucontext).uc_mcontext.pc as usize };
 
-                #[cfg(all(target_arch = "aarch64", target_os = "freebsd"))]
+                #[cfg(all(target_arch = "aarch64", any(target_os = "freebsd", target_os = "netbsd")))]
                 let addr = unsafe { (*ucontext).mc_gpregs.gp_elr as usize };
 
                 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]


### PR DESCRIPTION
This _seems_ to work OK: the included tests pass and I've tried profiling simple demo programs (single-threaded, multi-threaded, and async using tokio) and the flame graphs look reasonable for all of them.

However, for a more complex application (the one I really want to profile), all I get in the flame graph is this:

```
all
124947466617856
___lwp_park60
<pprof::backtrace::backtrace_rs::Trace as pprof::backtrace::Trace>::trace
backtrace::backtrace::trace_unsynchronized
backtrace::backtrace::libunwind::trace
```

whereas running the same code on Linux shows a reasonable flame graph. So, something still looks amiss but I don't know what it is.