### PR TITLE
Use `spin-rs` to replace parking lot to avoid deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,9 +541,9 @@ checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -646,29 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,7 +697,6 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
- "parking_lot",
  "prost",
  "prost-build",
  "prost-derive",
@@ -729,6 +705,7 @@ dependencies = [
  "rand",
  "sha2",
  "smallvec",
+ "spin",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.12",
@@ -1066,6 +1043,15 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.9"
 libc = "^0.2.66"
 log = "0.4"
 nix = { version = "0.26", default-features = false, features = ["signal", "fs"] }
-parking_lot = "0.12"
+spin = "0.10"
 tempfile = "3.1"
 thiserror = "2.0"
 findshlibs = "0.10"

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -6,8 +6,8 @@ use std::time::SystemTime;
 
 use nix::sys::signal;
 use once_cell::sync::Lazy;
-use parking_lot::RwLock;
 use smallvec::SmallVec;
+use spin::RwLock;
 
 #[cfg(any(
     target_arch = "x86_64",

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
-use parking_lot::RwLock;
+use spin::RwLock;
 
 use crate::frames::{Frames, UnresolvedFrames};
 use crate::profiler::Profiler;


### PR DESCRIPTION
Ref https://github.com/tikv/tikv/issues/18474, https://github.com/tikv/pprof-rs/pull/29

The parking lot is not actually a spinlock. And the `spin-rs` is still actively maintained 🍻 . We should use `spin-rs` instead!
