### PR TITLE
chore: Fix clippy warning in latest rust stable

### DIFF
--- a/src/frames.rs
+++ b/src/frames.rs
@@ -69,8 +69,7 @@ impl PartialEq for UnresolvedFrames {
             false
         } else {
             Iterator::zip(frames1.iter(), frames2.iter())
-                .map(|(s1, s2)| s1.symbol_address() == s2.symbol_address())
-                .all(|equal| equal)
+                .all(|(s1, s2)| s1.symbol_address() == s2.symbol_address())
         }
     }
 }


### PR DESCRIPTION
Fix clippy warning in latest rust stable (1.87.0) related to an usage of a `map` followed by an `all` identity as decribed [here](https://rust-lang.github.io/rust-clippy/master/index.html#map_all_any_identity).