### PR TITLE
chore: Appease rustc linter warnings v1.89

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -80,7 +80,7 @@ impl<T: Eq> Bucket<T> {
         }
     }
 
-    pub fn iter(&self) -> BucketIterator<T> {
+    pub fn iter(&self) -> BucketIterator<'_, T> {
         BucketIterator::<T> {
             related_bucket: self,
             index: 0,

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -129,11 +129,11 @@ impl Symbol {
         demangle(&String::from_utf8_lossy(self.raw_name())).into_owned()
     }
 
-    pub fn sys_name(&self) -> Cow<str> {
+    pub fn sys_name(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.raw_name())
     }
 
-    pub fn filename(&self) -> Cow<str> {
+    pub fn filename(&self) -> Cow<'_, str> {
         self.filename
             .as_ref()
             .map(|name| name.as_os_str().to_string_lossy())

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -197,7 +197,7 @@ impl ProfilerGuard<'_> {
     }
 
     /// Generate a report
-    pub fn report(&self) -> ReportBuilder {
+    pub fn report(&self) -> ReportBuilder<'_> {
         ReportBuilder::new(
             self.profiler,
             self.timer.as_ref().map(Timer::timing).unwrap_or_default(),


### PR DESCRIPTION
As described in the Rust-1.89 blog, [mismatched_lifetime_syntaxes](https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/) is now a stable lint that is cropping up in this crate.