### PR TITLE
framehop: remove the allocation in signal handle of framehop

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,10 +152,16 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --features flamegraph,prost-codec --target ${{ matrix.target }}
+          args: --features flamegraph,prost-codec --target ${{ matrix.target }} -- --test-threads 1
 
       - name: Run cargo test protobuf
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --features flamegraph,protobuf-codec --target ${{ matrix.target }}
+          args: --features flamegraph,protobuf-codec --target ${{ matrix.target }} -- --test-threads 1
+
+      - name: Run cargo test framehop
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --features flamegraph,protobuf-codec,framehop-unwinder --target ${{ matrix.target }} -- --test-threads 1

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -43,6 +43,9 @@ pub trait Frame: Sized + Clone {
 pub trait Trace {
     type Frame;
 
+    // init will be called before running the first trace in signal handler
+    fn init() {}
+
     fn trace<F: FnMut(&Self::Frame) -> bool>(_: *mut libc::c_void, cb: F)
     where
         Self: Sized;


### PR DESCRIPTION
close #281

1. Initialize the `FramehopUnwinder` before the first call to the `perf_signal_handler`.
2. Add a test to make sure the signal handler doesn't have memory allocation.
3. Modify the github action to run related tests for framehop. I believe framehop will be a better choice (than `backtrace-rs`) in the future.
4. Modify the code to use `spin::RwLock` instead of the `static mut`, though there is no safety issue actually.