### PR TITLE
Bump memmap2 to 0.9.11 to fix RUSTSEC-2026-0186

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,7 +813,7 @@ dependencies = [
  "inferno",
  "libc",
  "log",
- "memmap2",
+ "memmap2 0.9.11",
  "nix",
  "object 0.29.0",
  "once_cell",
@@ -1183,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac08504d60cf5bdffeb8a6a028f1a4868a5da1098bb19eb46239440039163fb"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.5.10",
  "stable_deref_trait",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ aligned-vec = "0.6"
 
 # framehop unwinder dependencies
 framehop = { version = "0.13", optional = true }
-memmap2 = { version = "0.5.5", optional = true }
+memmap2 = { version = "0.9.11", optional = true }
 object = { version = "0.29.0", optional = true }
 arc-swap = { version = "1.7.1", optional = true }
 


### PR DESCRIPTION
## Summary

Bumps the `framehop-unwinder` dependency `memmap2` from `^0.5.5` to `0.9.11`, fixing [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) (unchecked pointer offset in `advise_range`/`flush_range`). The `^0.5` cap currently blocks consumers from resolving the patch.

- Only read-only `Mmap::map` is used ([`shlib.rs`](https://github.com/tikv/pprof-rs/blob/master/src/backtrace/framehop_unwinder/shlib.rs)); the affected `advise_range`/`flush_range` are never called. API unchanged across `0.5..=0.9`.
- MSRV-safe: memmap2 0.9.11 requires Rust 1.65 (pprof MSRV 1.74).
- A transitive `memmap2 0.5.x` via `symbolic-common` remains — independent of this direct dep, out of scope (upstream floor-raise: getsentry/symbolic#996).

## Testing Done

`aarch64-apple-darwin`:
- `cargo build` — clean.
- `cargo test --features flamegraph,protobuf-codec,framehop-unwinder -- --test-threads 1` — 10 unit + 3 doc tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core memory mapping dependency to improve performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->